### PR TITLE
[bot] Refactor: Use shared logger in cli.py

### DIFF
--- a/src/wwdctools/cli.py
+++ b/src/wwdctools/cli.py
@@ -12,13 +12,11 @@ from rich.console import Console
 from rich.logging import RichHandler
 from rich.panel import Panel
 
+from .logger import logger
 from wwdctools.downloader import download_session_content
 from wwdctools.session import WWDCSession, fetch_session_data
 
 console = Console()
-
-# Configure logger
-logger = logging.getLogger("wwdctools")
 
 
 def configure_logging(verbose: bool) -> None:

--- a/src/wwdctools/cli.py
+++ b/src/wwdctools/cli.py
@@ -12,9 +12,10 @@ from rich.console import Console
 from rich.logging import RichHandler
 from rich.panel import Panel
 
-from .logger import logger
 from wwdctools.downloader import download_session_content
 from wwdctools.session import WWDCSession, fetch_session_data
+
+from .logger import logger
 
 console = Console()
 


### PR DESCRIPTION
I've updated `src/wwdctools/cli.py` to use the common logger instance from `src/wwdctools/logger.py` instead of a local one.

This change centralizes the logger configuration and usage, ensuring consistent logging behavior across the application.

I also verified that verbose logging still functions correctly after the change.